### PR TITLE
Fix IE7/8/9 bug

### DIFF
--- a/jquery.jWindowCrop.js
+++ b/jquery.jWindowCrop.js
@@ -34,7 +34,6 @@
 			base.$frame.append('<div class="jwc_controls" style="display:'+(base.options.showControlsOnStart ? 'block' : 'none')+';"><span>click to drag</span><a href="#" class="jwc_zoom_in"></a><a href="#" class="jwc_zoom_out"></a></div>');
 			base.$frame.css({'overflow': 'hidden', 'position': 'relative', 'width': base.options.targetWidth, 'height': base.options.targetHeight});
 			base.$image.css({'position': 'absolute', 'top': '0px', 'left': '0px'});
-			initializeDimensions();
 
 			base.$frame.find('.jwc_zoom_in').on('click.'+base.namespace, base.zoomIn);
 			base.$frame.find('.jwc_zoom_out').on('click.'+base.namespace, base.zoomOut);


### PR DESCRIPTION
initializeDimensions is called two times, once in the init method and again in the handeImageLoad method. On InternetExplorer, sometimes, the first call is executed before the image is load, so sometimes the plugin fail in IE.
