### PR TITLE
Remove max-width/max-height constraints

### DIFF
--- a/jWindowCrop.css
+++ b/jWindowCrop.css
@@ -1,6 +1,8 @@
 .jwc_frame {
 } .jwc_image {
 	cursor:move;
+	max-width:none;
+	max-height:none;
 } .jwc_controls {
 	background-color:#000;
 	width:100%; height:26px;


### PR DESCRIPTION
If the image has an inherited `max-width` or `max-height` CSS attribute, the plugin does not render properly.  This fixes that problem.
