### PR TITLE
Update jquery.jWindowCrop.js

### DIFF
--- a/jquery.jWindowCrop.js
+++ b/jquery.jWindowCrop.js
@@ -48,7 +48,8 @@
 
 		base.destroy = function() {
 			base.$image.removeData("jWindowCrop"); // remove data
-			$(document).unbind(); // remove body binds
+			$(document).unbind('mousemove.'+base.namespace+' touchmove.'+base.namespace); // remove body binds
+			$(document).unbind('mouseup.'+base.namespace+' touchend.'+base.namespace); // remove body binds
 			base.$image.unbind(); // remove image binds
 			base.$frame.unbind(); // remove frame binds
 			base.$frame.find('.jwc_zoom_out').unbind(); // remove zoom triggers


### PR DESCRIPTION
destro() unbind only attached events on document. not all events
